### PR TITLE
Test/add unit test project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Messaging.Buffer/bin/
 Messaging.Buffer/obj/
 Messaging.Buffer.Test/bin/
 Messaging.Buffer.Test/obj/
+TestResults/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Messaging.Buffer.TestApp/bin/
 Messaging.Buffer.TestApp/obj/
 Messaging.Buffer/bin/
 Messaging.Buffer/obj/
+Messaging.Buffer.Test/bin/
+Messaging.Buffer.Test/obj/

--- a/Messaging.Buffer.Test/GlobalUsings.cs
+++ b/Messaging.Buffer.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Messaging.Buffer.Test/Messaging.Buffer.Test.csproj
+++ b/Messaging.Buffer.Test/Messaging.Buffer.Test.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Messaging.Buffer\Messaging.Buffer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Messaging.Buffer.Test/MessagingTest/MessagingTestBase.cs
+++ b/Messaging.Buffer.Test/MessagingTest/MessagingTestBase.cs
@@ -31,12 +31,15 @@ namespace Messaging.Buffer.Test.MessagingTest
     {
         protected Messaging _service;
         protected Mock<IRedisCollection> _redisCollectionMock;
+        protected Mock<ISubscriber> _subscriberMock;
         protected Mock<ILogger<Messaging>> _loggerMock;
 
         public MessagingTestBase()
         {
             _loggerMock = new();
             _redisCollectionMock = new();
+            _subscriberMock = new();
+            _redisCollectionMock.Setup(x => x.GetSubscriber()).Returns(_subscriberMock.Object);
             _service = new Messaging(_loggerMock.Object, _redisCollectionMock.Object);
         }
     }

--- a/Messaging.Buffer.Test/MessagingTest/MessagingTestBase.cs
+++ b/Messaging.Buffer.Test/MessagingTest/MessagingTestBase.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class TestRequest : RequestBase
+    {
+        public string key { get; set; } = "value";
+    }
+    public class TestResponse : ResponseBase
+    {
+        public TestResponse(string correlationId) : base(correlationId)
+        {
+        }
+
+        public string key { get; set; } = "value";
+    }
+
+    public class MessagingTestBase
+    {
+        protected Messaging _service;
+        protected Mock<IRedisCollection> _redisCollectionMock;
+        protected Mock<ILogger<Messaging>> _loggerMock;
+
+        public MessagingTestBase()
+        {
+            _loggerMock = new();
+            _redisCollectionMock = new();
+            _service = new Messaging(_loggerMock.Object, _redisCollectionMock.Object);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class TestRequest() : RequestBase
+    {
+        public string key { get; set; } = "value";
+    }
+
+    public class OnRequest_Should
+    {
+        private Messaging _service;
+        private Mock<IRedisCollection> _redisCollectionMock;
+        private Mock<ILogger<Messaging>> _loggerMock;
+
+        public OnRequest_Should()
+        {
+            _loggerMock = new();
+            _redisCollectionMock = new();
+            _service = new Messaging(_loggerMock.Object, _redisCollectionMock.Object);
+        }
+
+        [Fact]
+        public void InvokeHandler_WhenFound()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}:{nameof(TestRequest)}";
+            var value = new TestRequest().ToJson();
+
+            var handlerInvoked = false;
+            var added = _service.RequestDelegateCollection.TryAdd("TestRequest", (string a, TestRequest b) =>
+            {
+                handlerInvoked = true;
+                Assert.Equal(requestId, a);
+                Assert.Equal("value", b.key);
+            });
+
+            // Act
+            _service.OnRequest(RedisChannel.Pattern(channel), value);
+
+            // Assert
+            Assert.True(handlerInvoked);
+        }
+
+        [Fact]
+        public void LogError_WhenHandlingFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}:{nameof(TestRequest)}";
+            var value = new TestRequest().ToJson();
+
+            var handlerInvoked = false;
+            var added = _service.RequestDelegateCollection.TryAdd("TestRequest", (string a, TestRequest b) =>
+            {
+                throw new Exception("Invoke did not work");
+            });
+
+            // Act
+            _service.OnRequest(RedisChannel.Pattern(channel), value);
+
+            // Assert
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Request could not be handled. Error when calling delegate.")),
+                        null,
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+            Assert.False(handlerInvoked);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
@@ -71,7 +71,7 @@ namespace Messaging.Buffer.Test.MessagingTest
         }
 
         [Fact]
-        public void FireRequestEvent_WhenNoDedicatedDelegate()
+        public void FireRequestReceived_WhenNoDedicatedDelegate()
         {
             // Arrange
             var requestId = Guid.NewGuid().ToString();

--- a/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
@@ -21,6 +21,16 @@ namespace Messaging.Buffer.Test.MessagingTest
 
         }
 
+        [Theory]
+        [InlineData("singlepath")]
+        [InlineData("double:path")]
+        [InlineData("This:is:four:path")]
+        public void ThrowException_WhenUnexpectedChannel(string channel)
+        {
+            // Act
+            Assert.Throws<Exception>(() => _service.OnRequest(RedisChannel.Pattern(channel), new TestRequest().ToJson()));
+        }
+
         [Fact]
         public void InvokeHandler_WhenFound()
         {

--- a/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnRequest_Should.cs
@@ -120,7 +120,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             // Assert
             _loggerMock.Verify(x => x.Log(LogLevel.Error,
                         It.IsAny<EventId>(),
-                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Request could not be find any handler associated to the request. Request not handled.")),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Could not find any handler associated to the request. Request not handled.")),
                         null,
                         It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
             Assert.False(handlerInvoked);

--- a/Messaging.Buffer.Test/MessagingTest/OnResponse_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnResponse_Should.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class OnResponseShould : MessagingTestBase
+    {
+        public OnResponseShould() : base()
+        {
+
+        }
+
+        [Fact]
+        public void InvokeHandler_WhenFound()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId).ToJson();
+
+            var handlerInvoked = false;
+            var added = _service.ResponseDelegateCollection.TryAdd(requestId, (Messaging a, ReceivedEventArgs b) =>
+            {
+                handlerInvoked = true;
+                Assert.NotNull(a);
+                Assert.Equal(channel, b.Channel);
+                Assert.Equal(value, b.Value);
+                Assert.Equal(requestId, b.CorrelationId);
+            });
+
+            // Act
+            _service.OnResponse(RedisChannel.Pattern(channel), value);
+
+            // Assert
+            Assert.True(handlerInvoked);
+        }
+
+        [Fact]
+        public void LogError_WhenHandlingFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId).ToJson();
+
+            var added = _service.ResponseDelegateCollection.TryAdd(requestId, (Messaging a, ReceivedEventArgs b) =>
+            {
+                throw new Exception("Handling failed.");
+            });
+
+            // Act
+            _service.OnResponse(RedisChannel.Pattern(channel), value);
+
+            // Assert
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Response could not be handled. Error when calling delegate.")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public void LogError_WhenNoHandlerFound()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}";
+            var value = new TestRequest().ToJson();
+
+            var handlerInvoked = false;
+
+            // Act
+            _service.OnResponse(RedisChannel.Pattern(channel), value);
+
+            // Assert
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("No Respons delegate found. Could not handle the response.")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+            Assert.False(handlerInvoked);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/OnResponse_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/OnResponse_Should.cs
@@ -21,6 +21,15 @@ namespace Messaging.Buffer.Test.MessagingTest
 
         }
 
+        [Theory]
+        [InlineData("singlepath")]
+        [InlineData("Is:Three:path")]
+        public void ThrowException_WhenUnexpectedChannel(string channel)
+        {
+            // Act
+            Assert.Throws<Exception>(() => _service.OnResponse(RedisChannel.Pattern(channel), new TestRequest().ToJson()));
+        }
+
         [Fact]
         public void InvokeHandler_WhenFound()
         {

--- a/Messaging.Buffer.Test/MessagingTest/PublishRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/PublishRequestAsync_Should.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class PublishRequestAsync_Should : MessagingTestBase
+    {
+        public PublishRequestAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void PublishMessage()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}:{typeof(TestRequest)}";
+            var value = new TestRequest();
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).ReturnsAsync(1).Verifiable();
+
+            // Act
+            var result = await _service.PublishRequestAsync(requestId, value);
+
+            // Assert
+            Assert.Equal(1, result);
+            _subscriberMock.Verify();
+        }
+
+        [Fact]
+        public async void LogWargning_WhenNoReceiver()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}:{typeof(TestRequest)}";
+            var value = new TestRequest();
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).ReturnsAsync(0).Verifiable();
+
+            // Act
+            var result = await _service.PublishRequestAsync(requestId, value);
+
+            // Assert
+            Assert.Equal(0, result);
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Warning,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Request of type {typeof(TestRequest)} {requestId} lost.")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public async void LogError_WhenPublishFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Request:{requestId}:{typeof(TestRequest)}";
+            var value = new TestRequest();
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).Throws(new Exception("publish failed")).Verifiable();
+
+            // Act
+            var result = await _service.PublishRequestAsync(requestId, value);
+
+            // Assert
+            Assert.Equal(0, result);
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Publish {typeof(TestRequest)} to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/PublishResponseAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/PublishResponseAsync_Should.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class PublishResponseAsync_Should : MessagingTestBase
+    {
+        public PublishResponseAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void PublishMessage()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId);
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).ReturnsAsync(1).Verifiable();
+
+            // Act
+            await _service.PublishResponseAsync(requestId, value);
+
+            // Assert
+            _subscriberMock.Verify();
+        }
+
+        [Fact]
+        public async void LogWargning_WhenNoReceiver()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId);
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).ReturnsAsync(0).Verifiable();
+
+            // Act
+            await _service.PublishResponseAsync(requestId, value);
+
+            // Assert
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Warning,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Response for of type {typeof(TestResponse)} with correlation id {requestId} lost.")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public async void LogWargning_WhenMoreThanOneReceiver()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId);
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).ReturnsAsync(2).Verifiable();
+
+            // Act
+            await _service.PublishResponseAsync(requestId, value);
+
+            // Assert
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Warning,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"More than one instance received the Response of type {typeof(TestResponse)} with correlation id {requestId}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public async void LogError_WhenPublishFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            var value = new TestResponse(requestId);
+            var expectedMessageSent = value.ToJson();
+            _subscriberMock.Setup(x => x.PublishAsync(RedisChannel.Pattern(channel), expectedMessageSent, CommandFlags.None)).Throws(new Exception("Publish fails.")).Verifiable();
+
+            // Act
+            await _service.PublishResponseAsync(requestId, value);
+
+            // Assert
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Publish response {typeof(TestResponse)} to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
@@ -33,7 +33,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             await _service.SubscribeAnyRequestAsync((object sender, ReceivedEventArgs e) => {  });
 
             // Assert
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             await _service.SubscribeAnyRequestAsync((object sender, ReceivedEventArgs e) => { });
 
             // Assert
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
 
             _loggerMock.Verify(x => x.Log(LogLevel.Error,
                         It.IsAny<EventId>(),

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class SubscribeAnyRequestAsync_Should : MessagingTestBase
+    {
+        public SubscribeAnyRequestAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void SubscribeToGenericRequestChannel()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable();
+
+            // Act
+            await _service.SubscribeAnyRequestAsync((object sender, ReceivedEventArgs e) => {  });
+
+            // Assert
+            _subscriberMock.Verify();
+        }
+
+        [Fact]
+        public async void LogError_WhenSubscriptionFails()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Throws(new Exception("Subscription fails.")).Verifiable();
+
+            // Act
+            await _service.SubscribeAnyRequestAsync((object sender, ReceivedEventArgs e) => { });
+
+            // Assert
+            _subscriberMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class SubscribeRequestAsync_Should : MessagingTestBase
+    {
+        public SubscribeRequestAsync_Should() : base()
+        {
+
+        }
+
+        private void TestRequestHandler(string correlationId, TestRequest req)
+        {
+
+        }
+
+        [Fact]
+        public async void SubscribeToRequestChannel()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable();
+
+            // Act
+            await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
+
+            // Assert
+            Assert.Single(_service.RequestDelegateCollection);
+            Assert.Equal(TestRequestHandler, _service.RequestDelegateCollection[$"{typeof(TestRequest)}"]);
+            _subscriberMock.Verify();
+        }
+
+        [Fact]
+        public async void LogError_WhenSubscriptionFails()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Throws(new Exception("Subscribe fails.")).Verifiable();
+
+            // Act
+            await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
+
+            // Assert
+            _subscriberMock.Verify();
+            Assert.Empty(_service.RequestDelegateCollection);
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
@@ -41,7 +41,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             // Assert
             Assert.Single(_service.RequestDelegateCollection);
             Assert.Equal(TestRequestHandler, _service.RequestDelegateCollection[$"{typeof(TestRequest)}"]);
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
 
             // Assert
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
             Assert.Empty(_service.RequestDelegateCollection);
 
             _loggerMock.Verify(x => x.Log(LogLevel.Error,

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeResponseAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeResponseAsync_Should.cs
@@ -33,7 +33,7 @@ namespace Messaging.Buffer.Test.MessagingTest
         {
             // Arrange
             var requestId = Guid.NewGuid().ToString();
-            var channel = $"Response:*";
+            var channel = $"Response:{requestId}";
             _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnResponse)).Verifiable();
 
             // Act
@@ -42,7 +42,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             // Assert
             Assert.Single(_service.ResponseDelegateCollection);
             Assert.Equal(TestResponseHandler, _service.ResponseDelegateCollection[$"{requestId}"]);
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Messaging.Buffer.Test.MessagingTest
             await _service.SubscribeResponseAsync(requestId, TestResponseHandler);
 
             // Assert
-            _subscriberMock.Verify();
+            _redisCollectionMock.Verify();
             Assert.Empty(_service.ResponseDelegateCollection);
 
             _loggerMock.Verify(x => x.Log(LogLevel.Error,

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeResponseAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeResponseAsync_Should.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class SubscribeResponseAsync_Should : MessagingTestBase
+    {
+        public SubscribeResponseAsync_Should() : base()
+        {
+
+        }
+
+        private void TestResponseHandler(object obj, ReceivedEventArgs args)
+        {
+
+        }
+
+        [Fact]
+        public async void SubscribeToResponseChannel()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:*";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnResponse)).Verifiable();
+
+            // Act
+            await _service.SubscribeResponseAsync(requestId, TestResponseHandler);
+
+            // Assert
+            Assert.Single(_service.ResponseDelegateCollection);
+            Assert.Equal(TestResponseHandler, _service.ResponseDelegateCollection[$"{requestId}"]);
+            _subscriberMock.Verify();
+        }
+
+        [Fact]
+        public async void LogError_WhenSubscriptionFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnResponse)).Throws(new Exception("Subscription fails.")).Verifiable();
+
+            // Act
+            await _service.SubscribeResponseAsync(requestId, TestResponseHandler);
+
+            // Assert
+            _subscriberMock.Verify();
+            Assert.Empty(_service.ResponseDelegateCollection);
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/UnsubscribeAnyRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/UnsubscribeAnyRequestAsync_Should.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class UnsubscribeAnyRequestAsync_Should : MessagingTestBase
+    {
+        public UnsubscribeAnyRequestAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void UnsubscribeFromGenericRequestChannel()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Verifiable();
+
+            // Act
+            await _service.UnsubscribeAnyRequestAsync();
+
+            // Assert
+            _redisCollectionMock.Verify();
+        }
+
+        [Fact]
+        public async void LogError_WhenUnsubFails()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Throws(new Exception("Unsub fails.")).Verifiable();
+
+            // Act
+            await _service.UnsubscribeAnyRequestAsync();
+
+            // Assert
+            _redisCollectionMock.Verify();
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Unsubscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/UnsubscribeRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/UnsubscribeRequestAsync_Should.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class UnsubscribeRequestAsync_Should : MessagingTestBase
+    {
+        public UnsubscribeRequestAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void UnsubscribeFromRequestChannel()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Verifiable();
+            _service.RequestDelegateCollection.TryAdd($"{typeof(TestRequest)}", () => { });
+
+            // Act
+            await _service.UnsubscribeRequestAsync<TestRequest>();
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.Empty(_service.RequestDelegateCollection);
+        }
+
+        [Fact]
+        public async void LogError_WhenUnsubFails()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Throws(new Exception("Unsub fails.")).Verifiable();
+            _service.RequestDelegateCollection.TryAdd($"{typeof(TestRequest)}", () => { });
+
+            // Act
+            await _service.UnsubscribeRequestAsync<TestRequest>();
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.NotEmpty(_service.RequestDelegateCollection);
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Unsubscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.Test/MessagingTest/UnsubscribeResponseAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/UnsubscribeResponseAsync_Should.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Redis;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using Xunit.Sdk;
+
+namespace Messaging.Buffer.Test.MessagingTest
+{
+    public class UnsubscribeResponseAsync_Should : MessagingTestBase
+    {
+        public UnsubscribeResponseAsync_Should() : base()
+        {
+
+        }
+
+        [Fact]
+        public async void UnsubscribeFromResponseChannel()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Verifiable();
+            _service.ResponseDelegateCollection.TryAdd($"{requestId}", () => { });
+
+            // Act
+            await _service.UnsubscribeResponseAsync(requestId);
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.Empty(_service.ResponseDelegateCollection);
+        }
+
+        [Fact]
+        public async void LogError_WhenUnsubFails()
+        {
+            // Arrange
+            var requestId = Guid.NewGuid().ToString();
+            var channel = $"Response:{requestId}";
+            _redisCollectionMock.Setup(x => x.UnsubscribeAsync(RedisChannel.Pattern(channel))).Throws(new Exception("Unsub fails.")).Verifiable();
+            _service.ResponseDelegateCollection.TryAdd($"{requestId}", () => { });
+
+            // Act
+            await _service.UnsubscribeResponseAsync(requestId);
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.NotEmpty(_service.ResponseDelegateCollection);
+
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Unsubscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+    }
+}

--- a/Messaging.Buffer.sln
+++ b/Messaging.Buffer.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messaging.Buffer", "Messaging.Buffer\Messaging.Buffer.csproj", "{7186FE64-DD1B-48F7-9943-858A108904CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Messaging.Buffer", "Messaging.Buffer\Messaging.Buffer.csproj", "{7186FE64-DD1B-48F7-9943-858A108904CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messaging.Buffer.TestApp", "Messaging.Buffer.TestApp\Messaging.Buffer.TestApp.csproj", "{ABF2E07C-13A0-4B28-B21B-E64F0245F623}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Messaging.Buffer.TestApp", "Messaging.Buffer.TestApp\Messaging.Buffer.TestApp.csproj", "{ABF2E07C-13A0-4B28-B21B-E64F0245F623}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messaging.Buffer.Test", "Messaging.Buffer.Test\Messaging.Buffer.Test.csproj", "{E2782CFF-3935-4D2A-80F8-7C0E5F066F69}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{ABF2E07C-13A0-4B28-B21B-E64F0245F623}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABF2E07C-13A0-4B28-B21B-E64F0245F623}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABF2E07C-13A0-4B28-B21B-E64F0245F623}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2782CFF-3935-4D2A-80F8-7C0E5F066F69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2782CFF-3935-4D2A-80F8-7C0E5F066F69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2782CFF-3935-4D2A-80F8-7C0E5F066F69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2782CFF-3935-4D2A-80F8-7C0E5F066F69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -121,7 +121,7 @@ namespace Messaging.Buffer
         /// </summary>
         /// <param name="channel"></param>
         /// <param name="value"></param>
-        private void OnResponse(RedisChannel channel, RedisValue value)
+        internal void OnResponse(RedisChannel channel, RedisValue value)
         {
             _logger.LogTrace("Response Received from {Channel}", channel);
             var channelPath = channel.ToString().Split(":");
@@ -152,6 +152,10 @@ namespace Messaging.Buffer
                 {
                     _logger.LogError(ex, "Response could not be handled. Error when calling delegate.");
                 }
+            }
+            else
+            {
+                _logger.LogError("No Respons delegate found. Could not handle the response.");
             }
         }
 

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -307,7 +307,7 @@ namespace Messaging.Buffer
                 _logger.LogTrace("Unsuscribing channel {Channel}", channel);
                 await _redisCollection.UnsubscribeAsync(RedisChannel.Pattern(channel));
 
-                if (!ResponseDelegateCollection.TryRemove(type.FullName, out Delegate handler))
+                if (!RequestDelegateCollection.TryRemove(type.FullName, out Delegate handler))
                     throw new Exception("Could not remove OnResponse delegate from dictionnary.");
             }
             catch (Exception ex)

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -40,6 +40,7 @@ namespace Messaging.Buffer
             ResponseDelegateCollection = new();
         }
 
+        // Todo: Test performance on this method
         private static Type ByName(string name)
         {
             return
@@ -67,6 +68,9 @@ namespace Messaging.Buffer
         {
             _logger.LogTrace("Request Received from {Channel}", channel);
             var channelPath = channel.ToString().Split(":");
+
+            if (channelPath.Length != 3)
+                throw new Exception($"Unexpected channel format from received message. Channel: {channel}");
 
             ReceivedEventArgs eventArgs = new ReceivedEventArgs()
             {
@@ -125,6 +129,9 @@ namespace Messaging.Buffer
         {
             _logger.LogTrace("Response Received from {Channel}", channel);
             var channelPath = channel.ToString().Split(":");
+
+            if (channelPath.Length != 2)
+                throw new Exception($"Unexpected channel format from received message. Channel: {channel}");
 
             ReceivedEventArgs eventArgs = new ReceivedEventArgs()
             {

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -108,14 +108,13 @@ namespace Messaging.Buffer
             else
             {
                 // case: generic handler (deprecated soon)
-                EventHandler<ReceivedEventArgs> handler2 = RequestReceived;
-                if (handler2 != null)
+                if (RequestReceived != null)
                 {
-                    handler2(this, e);
+                    RequestReceived(this, e);
                 }
                 else
                 {
-                    _logger.LogError("Request could not be find any handler associated to the request. Request not handled.");
+                    _logger.LogError("Could not find any handler associated to the request. Request not handled.");
                 }
             }
         }
@@ -254,6 +253,7 @@ namespace Messaging.Buffer
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Could not Subscribe to channel {Channel}", channel);
+                RequestDelegateCollection.TryRemove(type, out var temp);
             }
         }
 

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -288,6 +288,8 @@ namespace Messaging.Buffer
             {
                 _logger.LogTrace("Unsuscribing channel {Channel}", channel);
                 await _redisCollection.UnsubscribeAsync(RedisChannel.Pattern(channel));
+
+                RequestReceived = null;
             }
             catch (Exception ex)
             {

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -272,6 +272,7 @@ namespace Messaging.Buffer
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Could not Subscribe to channel {Channel}", channel);
+                ResponseDelegateCollection.TryRemove(correlationId, out var temp);
             }
         }
 

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -109,6 +109,10 @@ namespace Messaging.Buffer
                 {
                     handler2(this, e);
                 }
+                else
+                {
+                    _logger.LogError("Request could not be find any handler associated to the request. Request not handled.");
+                }
             }
         }
 


### PR DESCRIPTION
Test : Added unit test for class Messaging.cs

Added: 
- Channel format verification when received request or response
- Error Log when no handler is found for a request or response is received.

Fixed: 
- Possible Request deserialization issue when handling Request
- A request handler registration was not reverted correctly when subscribing to a request or response failed.
- Added missing Event clear when unsubscribing to any request.
- Unsubscribing a request was not clearing the handler collection correctly