### PR TITLE
Feature: Throwing exception on conflicting subscriptions

### DIFF
--- a/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeAnyRequestAsync_Should.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Exceptions;
 using Messaging.Buffer.Redis;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -28,9 +29,10 @@ namespace Messaging.Buffer.Test.MessagingTest
             // Arrange
             var channel = "Request:*:*";
             _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable();
+            EventHandler<ReceivedEventArgs> OnRequestTest = (object sender, ReceivedEventArgs e) => { };
 
             // Act
-            await _service.SubscribeAnyRequestAsync((object sender, ReceivedEventArgs e) => {  });
+            await _service.SubscribeAnyRequestAsync(OnRequestTest);
 
             // Assert
             _redisCollectionMock.Verify();
@@ -54,6 +56,64 @@ namespace Messaging.Buffer.Test.MessagingTest
                         It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
                         It.IsAny<Exception>(),
                         It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public async void ThrowException_WhenSubscribingTwice()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable(Times.Once);
+            EventHandler<ReceivedEventArgs> OnRequestTest = (object sender, ReceivedEventArgs e) => { };
+
+            // Act
+            await _service.SubscribeAnyRequestAsync(OnRequestTest);
+            var exception = await Assert.ThrowsAsync<SubscriptionException>(() => _service.SubscribeAnyRequestAsync(OnRequestTest));
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.Equal("The subscription for any request is done already.", exception.Message);
+        }
+
+        [Fact]
+        public async void AllowSubscription_OnSecondeTry()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _redisCollectionMock.SetupSequence(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest))
+                .Throws(new Exception("Subscription fails."))
+                .Returns(Task.CompletedTask);
+            EventHandler<ReceivedEventArgs> OnRequestTest = (object sender, ReceivedEventArgs e) => { };
+
+            // Act Once
+            await _service.SubscribeAnyRequestAsync(OnRequestTest);
+            _loggerMock.Verify(x => x.Log(LogLevel.Error,
+                        It.IsAny<EventId>(),
+                        It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
+                        It.IsAny<Exception>(),
+                        It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+
+            // Act Twice
+            await _service.SubscribeAnyRequestAsync(OnRequestTest);
+            _redisCollectionMock.Verify(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest), Times.Exactly(2));
+        }
+
+
+        [Fact]
+        public async void ThrowException_WhenConflictingWithRequestSubscription()
+        {
+            // Arrange
+            var channel = "Request:*:*";
+            _service.RequestDelegateCollection.TryAdd("any", null);
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(It.IsAny<RedisChannel>(), It.IsAny<Action<RedisChannel, RedisValue>>())).Verifiable(Times.Never);
+            EventHandler<ReceivedEventArgs> OnRequestTest = (object sender, ReceivedEventArgs e) => { };
+
+            // Act
+            var exception = await Assert.ThrowsAsync<SubscriptionException>(() => _service.SubscribeAnyRequestAsync(OnRequestTest));
+
+            // Assert
+            _redisCollectionMock.Verify();
+            Assert.Equal("Conflicting subscription detected. Cannot perform both request subscription and any request subscription at the same time.", exception.Message);
         }
     }
 }

--- a/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
+++ b/Messaging.Buffer.Test/MessagingTest/SubscribeRequestAsync_Should.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Exceptions;
 using Messaging.Buffer.Redis;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
@@ -63,6 +64,65 @@ namespace Messaging.Buffer.Test.MessagingTest
                         It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Could not Subscribe to channel {channel}")),
                         It.IsAny<Exception>(),
                         It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)), Times.Once);
+        }
+
+        [Fact]
+        public async void ThrowException_WhenSubscriptionToAnyRequest_AlreadyExists()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable(Times.Never);
+            await _service.SubscribeAnyRequestAsync((object e, ReceivedEventArgs evt) => { }); // inital condition: conflict, subscription  to any request already done.
+
+            // Act
+            var exception = await Assert.ThrowsAsync<SubscriptionException>(() => _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler));
+
+            // Assert
+            Assert.Empty(_service.RequestDelegateCollection);
+            Assert.Equal("A subscription for any request is done already. Cannot subscribe for requests independantly.", exception.Message);
+            _redisCollectionMock.Verify();
+        }
+
+        [Fact]
+        public async void ThrowException_WhenTheSubscription_AlreadyExists()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.Setup(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest)).Verifiable(Times.Once);
+
+            // Act once
+            await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
+
+            // Act twice 
+            var exception = await Assert.ThrowsAsync<SubscriptionException>(() => _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler));
+
+            // Assert
+            Assert.Single(_service.RequestDelegateCollection);
+            Assert.Equal(TestRequestHandler, _service.RequestDelegateCollection[$"{typeof(TestRequest)}"]);
+            Assert.Equal("This subscription already exists.", exception.Message);
+            _redisCollectionMock.Verify();
+        }
+
+        [Fact]
+        public async void AllowSubscription_OnSecondeTry()
+        {
+            // Arrange
+            var channel = $"Request:*:{typeof(TestRequest)}";
+            _redisCollectionMock.SetupSequence(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest))
+                .Throws(new Exception("Failed."))
+                .Returns(Task.CompletedTask);
+
+            // Act Once
+            await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
+            Assert.Empty(_service.RequestDelegateCollection);
+
+            // Act Twice
+            await _service.SubscribeRequestAsync<TestRequest>(TestRequestHandler);
+
+            // Assert
+            Assert.Single(_service.RequestDelegateCollection);
+            Assert.Equal(TestRequestHandler, _service.RequestDelegateCollection[$"{typeof(TestRequest)}"]);
+            _redisCollectionMock.Verify(x => x.SubscribeAsync(RedisChannel.Pattern(channel), _service.OnRequest), Times.Exactly(2));
         }
     }
 }

--- a/Messaging.Buffer.TestApp/Program.cs
+++ b/Messaging.Buffer.TestApp/Program.cs
@@ -59,6 +59,9 @@ public class Program
         await app.RunTotalCount();
         await app.RunTotalCount();
 
+        Console.WriteLine("***********  Subscription Conflicting on purpose ************");
+        await app.DoingShitOnPurpose();
+
         Console.WriteLine("***********  Test End ************");
         Console.WriteLine("*********************************");
         Console.WriteLine("***********  App will close in 5 min ************");

--- a/Messaging.Buffer/Buffer/HandlerBase.cs
+++ b/Messaging.Buffer/Buffer/HandlerBase.cs
@@ -27,9 +27,10 @@ namespace Messaging.Buffer.Buffer
         /// Subscribe to Redis
         /// </summary>
         /// <returns></returns>
-        public async Task Subscribe()
+        public async Task<string> Subscribe()
         {
             await _messaging.SubscribeRequestAsync<TRequest>(Handle);
+            return typeof(TRequest).Name;
         }
 
         /// <summary>

--- a/Messaging.Buffer/Exceptions/SubscriptionException.cs
+++ b/Messaging.Buffer/Exceptions/SubscriptionException.cs
@@ -1,0 +1,34 @@
+﻿namespace Messaging.Buffer.Exceptions
+{
+    /// <summary>
+    /// Exception for forbidden subscription
+    /// </summary>
+    public class SubscriptionException : Exception
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        public SubscriptionException()
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        public SubscriptionException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="inner"></param>
+        public SubscriptionException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/Messaging.Buffer/IMessaging.cs
+++ b/Messaging.Buffer/IMessaging.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Exceptions;
 
 namespace Messaging.Buffer
 {
@@ -43,25 +44,27 @@ namespace Messaging.Buffer
         /// <summary>
         /// Subscribe for Requests
         /// </summary>
-        /// <param name="OnRequest">Function called on request received</param>
+        /// <param name="requestHandler">Function called on request received</param>
+        /// <exception cref="SubscriptionException">Subscribtion already exists or is conflicting with another</exception>
         Task SubscribeAnyRequestAsync(EventHandler<ReceivedEventArgs> requestHandler);
 
         /// <summary>
         /// Subscribe for specific request
         /// </summary>
         /// <param name="requestHandler">Function called on request received</param>
+        /// <exception cref="SubscriptionException">Subscribtion already exists or is conflicting with another</exception>
         Task SubscribeRequestAsync<TRequest>(Action<string, TRequest> requestHandler) where TRequest : RequestBase;
 
         /// <summary>
         /// Subscribe for all request that has a handler defined
         /// </summary>
         /// <returns></returns>
+        /// <exception cref="SubscriptionException">Subscribtion already exists or is conflicting with another</exception>
         Task SubscribeHandlers();
 
         /// <summary>
         /// Unsubscribe for Requests
         /// </summary>
-        /// <param name="OnRequest">Function called on request received</param>
         Task UnsubscribeAnyRequestAsync();
 
         /// <summary>
@@ -72,13 +75,15 @@ namespace Messaging.Buffer
         /// <summary>
         /// Subscribe for response. 
         /// </summary>
-        /// <param name="OnRequest">Function called on request received</param>
+        /// <param name="correlationId">Buffer unique identifier</param>
+        /// <param name="responseHandler">Function called on request received</param>
+        /// <exception cref="SubscriptionException">Subscribtion already exists or is conflicting with another</exception>
         Task SubscribeResponseAsync(string correlationId, Action<object, ReceivedEventArgs> responseHandler);
 
         /// <summary>
         /// Unsubscribe for response. 
         /// </summary>
-        /// <param name="OnRequest">Function called on request received</param>
+        /// <param name="correlationId">Buffer unique identifier</param>
         Task UnsubscribeResponseAsync(string correlationId);
     }
 }

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -247,6 +247,7 @@ namespace Messaging.Buffer
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Could not Subscribe to channel {Channel}", channel);
+                RequestReceived -= requestHandler;
             }
         }
 

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Nodes;
 using Messaging.Buffer.Attributes;
 using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Exceptions;
 using Messaging.Buffer.Helpers;
 using Messaging.Buffer.Redis;
 using Messaging.Buffer.Service;
@@ -228,6 +230,12 @@ namespace Messaging.Buffer
         /// <inheritdoc/>
         public async Task SubscribeAnyRequestAsync(EventHandler<ReceivedEventArgs> requestHandler)
         {
+            if (RequestReceived is not null)
+                throw new SubscriptionException("The subscription for any request is done already.");
+
+            if (RequestDelegateCollection.Any())
+                throw new SubscriptionException("Conflicting subscription detected. Cannot perform both request subscription and any request subscription at the same time.");
+
             var channel = $"Request:*:*"; // subscribe to all possible request
             try
             {
@@ -246,6 +254,13 @@ namespace Messaging.Buffer
         public async Task SubscribeRequestAsync<TRequest>(Action<string, TRequest> requestHandler) where TRequest : RequestBase
         {
             var type = typeof(TRequest).FullName;
+
+            if (RequestReceived is not null)
+                throw new SubscriptionException("A subscription for any request is done already. Cannot subscribe for requests independantly.");
+
+            if (RequestDelegateCollection.ContainsKey(type))
+                throw new SubscriptionException("This subscription already exists.");
+
             var channel = $"Request:*:{type}"; // subscribe to TRequest
             try
             {
@@ -253,7 +268,7 @@ namespace Messaging.Buffer
                     throw new Exception($"Could not add request handler to collection. Subscription canceled.");
 
                 _logger.LogTrace("Subscribing to {Channel}", channel);
-                await _redisCollection.SubscribeAsync(RedisChannel.Pattern(channel), OnRequest); //All request
+                await _redisCollection.SubscribeAsync(RedisChannel.Pattern(channel), OnRequest);
             }
             catch (Exception ex)
             {
@@ -265,6 +280,9 @@ namespace Messaging.Buffer
         /// <inheritdoc/>
         public async Task SubscribeResponseAsync(string correlationId, Action<object, ReceivedEventArgs> responseHandler)
         {
+            if (ResponseDelegateCollection.ContainsKey(correlationId))
+                throw new SubscriptionException($"This subscription already exists");
+
             var channel = $"Response:{correlationId}";
             try
             {
@@ -281,14 +299,20 @@ namespace Messaging.Buffer
             }
         }
 
+        private List<string> HandlerSubscribedList = new List<string>();
+
         /// <inheritdoc/>
         public async Task SubscribeHandlers()
         {
             var Handlers = Reflexion.GetTypesWithAttribute<HandlerAttribute>();
             foreach (var handler in Handlers)
             {
+                if (HandlerSubscribedList.Contains(handler.Name))
+                    throw new SubscriptionException($"Dupplicate handler detected. Handler : {handler.Name}.");
+
                 dynamic handlerService = _serviceProvider.GetRequiredService(handler);
-                await handlerService.Subscribe();
+                string subscribed = await handlerService.Subscribe();
+                HandlerSubscribedList.Add(subscribed);
             }
         }
 

--- a/Messaging.Buffer/ReceivedEventArgs.cs
+++ b/Messaging.Buffer/ReceivedEventArgs.cs
@@ -1,5 +1,8 @@
 ﻿namespace Messaging.Buffer
 {
+    /// <summary>
+    /// Message received event args
+    /// </summary>
     public class ReceivedEventArgs : EventArgs
     {
         /// <summary>


### PR DESCRIPTION
When a conflicting subscription is made, throw an exception. 

Conficting subscription : 
- Subscribing to the same thing twice.
- Mixing subscription to Any request and Type request (not supported).
 
Subscribtion using handlers and for requests are compatible as long as they do not consume for the same request. 
(ie: it's **allowed** to subscribe using **Handler\<RequestA\>** while performing a **Subscribe\<RequestB\>** elsewhere).
(note: it's **forbidden** both using both **Handler\<RequestA\>** and **Subscribe\<RequestA\>**)