### PR TITLE
refacto: remove the need for HandleAttribute

### DIFF
--- a/Messaging.Buffer.TestApp/Handlers/HelloWorldHandler.cs
+++ b/Messaging.Buffer.TestApp/Handlers/HelloWorldHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Messaging.Buffer.TestApp.Handlers
 {
-    [Handler]
     public class HelloWorldHandler : HandlerBase<HelloWorldRequest>
     {
         public HelloWorldHandler(ILogger<HelloWorldHandler> logger, IMessaging messaging) : base(logger, messaging)

--- a/Messaging.Buffer.TestApp/Handlers/ListResourceHandler.cs
+++ b/Messaging.Buffer.TestApp/Handlers/ListResourceHandler.cs
@@ -1,0 +1,29 @@
+﻿using Messaging.Buffer.Attributes;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.TestApp.Requests;
+using Microsoft.Extensions.Logging;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Messaging.Buffer.TestApp.Handlers
+{
+    public class ListResourceHandler : HandlerBase<ListResourceRequest>
+    {
+        private Application _application;
+
+        public ListResourceHandler(ILogger<ListResourceHandler> logger, IMessaging messaging, Application application) : base(logger, messaging)
+        {
+            _application = application;
+        }
+
+        public override async void Handle(string correlationId, ListResourceRequest request)
+        {
+            _logger.LogTrace($"Handle: {nameof(ListResourceRequest)}");
+
+
+            await base.Respond(correlationId, new ListResourceResponse(correlationId)
+            {
+                ResourceList = _application.ResourceList
+            });
+        }
+    }
+}

--- a/Messaging.Buffer.TestApp/Handlers/TotalCoundHandler.cs
+++ b/Messaging.Buffer.TestApp/Handlers/TotalCoundHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Messaging.Buffer.TestApp.Handlers
 {
-    [Handler]
     public class TotalCountHandler : HandlerBase<TotalCountRequest>
     {
         public TotalCountHandler(ILogger<TotalCountHandler> logger, IMessaging messaging) : base(logger, messaging)

--- a/Messaging.Buffer.TestApp/Program.cs
+++ b/Messaging.Buffer.TestApp/Program.cs
@@ -22,14 +22,17 @@ public class Program
             // Register the service and any buffer
             .AddMessagingBuffer(Configuration, "Redis", (cfg) =>
             {
-                cfg.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse>();
-                cfg.AddBuffer<TotalCountRequestBuffer, TotalCountRequest, TotalCountResponse>();
-                cfg.RegisterHandlers();
+                cfg.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse, HelloWorldHandler>();
+                cfg.AddBuffer<TotalCountRequestBuffer, TotalCountRequest, TotalCountResponse, TotalCountHandler>();
+                cfg.AddBuffer<ListResourceRequestBuffer, ListResourceRequest, ListResourceResponse, ListResourceHandler>();
             })
 
             .BuildServiceProvider();
 
         var app = serviceProvider.GetService<Application>();
+
+        Console.WriteLine("***********  RunListResource_UsingHandler ************");
+        await app.RunListResource_UsingHandler();
 
         Console.WriteLine("***********  Test_Sub_Unsub_Resub ************");
         await app.Test_Sub_Unsub_Resub();

--- a/Messaging.Buffer.TestApp/Program.cs
+++ b/Messaging.Buffer.TestApp/Program.cs
@@ -19,7 +19,7 @@ public class Program
             .AddSingleton<Application>()
             .AddLogging(x => { x.AddConsole(); x.SetMinimumLevel(LogLevel.Information); })
 
-            // Register the service and any buffer
+            // Register and configure the service
             .AddMessagingBuffer(Configuration, "Redis", (cfg) =>
             {
                 cfg.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse, HelloWorldHandler>();

--- a/Messaging.Buffer.TestApp/Program.cs
+++ b/Messaging.Buffer.TestApp/Program.cs
@@ -20,14 +20,12 @@ public class Program
             .AddLogging(x => { x.AddConsole(); x.SetMinimumLevel(LogLevel.Information); })
 
             // Register the service and any buffer
-            .AddMessagingBuffer(Configuration, "Redis")
-
-            // Register buffer classes
-            .AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse>()
-            .AddBuffer<TotalCountRequestBuffer, TotalCountRequest, TotalCountResponse>()
-
-            // register handlers
-            .RegisterHandlers()
+            .AddMessagingBuffer(Configuration, "Redis", (cfg) =>
+            {
+                cfg.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse>();
+                cfg.AddBuffer<TotalCountRequestBuffer, TotalCountRequest, TotalCountResponse>();
+                cfg.RegisterHandlers();
+            })
 
             .BuildServiceProvider();
 

--- a/Messaging.Buffer.TestApp/Requests/ListResourceRequestBuffer.cs
+++ b/Messaging.Buffer.TestApp/Requests/ListResourceRequestBuffer.cs
@@ -1,0 +1,39 @@
+﻿using Messaging.Buffer.Buffer;
+using Microsoft.Extensions.Logging;
+
+namespace Messaging.Buffer.TestApp.Requests
+{
+    public class ListResourceRequest : RequestBase
+    {
+    }
+
+    public class ListResourceResponse : ResponseBase
+    {
+        public List<string> ResourceList { get; set; } = new();
+        public ListResourceResponse(string correlationId) : base(correlationId)
+        {
+        }
+    }
+
+    public class ListResourceRequestBuffer : RequestBufferBase<ListResourceRequest, ListResourceResponse>
+    {
+        public ListResourceRequestBuffer(IMessaging messaging, ListResourceRequest request, ILogger<ListResourceRequestBuffer> logger) : base(messaging, request, logger)
+        {
+        }
+
+        protected override ListResourceResponse Aggregate()
+        {
+            var response = new ListResourceResponse(CorrelationId);
+
+            foreach (var res in ResponseCollection)
+            {
+                foreach(var item in res.ResourceList)
+                {
+                    response.ResourceList.Add(res.ResponseServerName + ":" + item);
+                }                
+            }
+
+            return response;
+        }
+    }
+}

--- a/Messaging.Buffer/Attributes/HandlerAttribute.cs
+++ b/Messaging.Buffer/Attributes/HandlerAttribute.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Messaging.Buffer.Attributes
 {
-    public class HandlerAttribute : Attribute
+    internal class HandlerAttribute : Attribute
     {
     }
 }

--- a/Messaging.Buffer/Buffer/HandlerBase.cs
+++ b/Messaging.Buffer/Buffer/HandlerBase.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Messaging.Buffer.Attributes;
+using Microsoft.Extensions.Logging;
 
 namespace Messaging.Buffer.Buffer
 {
@@ -6,6 +7,7 @@ namespace Messaging.Buffer.Buffer
     /// Base class for handlers
     /// </summary>
     /// <typeparam name="TRequest"></typeparam>
+    [Handler]
     public abstract class HandlerBase<TRequest> where TRequest : RequestBase
     {
         protected IMessaging _messaging;

--- a/Messaging.Buffer/Helpers/Reflexion.cs
+++ b/Messaging.Buffer/Helpers/Reflexion.cs
@@ -19,7 +19,7 @@ namespace Messaging.Buffer.Helpers
         static public IEnumerable<Type> GetTypesWithAttribute<TAttribute>()
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            foreach (var assembly  in assemblies)
+            foreach (var assembly in assemblies)
             {
                 foreach (Type type in assembly.GetTypes())
                 {
@@ -29,7 +29,15 @@ namespace Messaging.Buffer.Helpers
                     }
                 }
             }
+        }
 
+        /// <summary>
+        /// Return the list of existing Handlers
+        /// </summary>
+        /// <returns></returns>
+        static public IEnumerable<Type> GetHandlerTypes()
+        {
+            return GetTypesWithAttribute<HandlerAttribute>().Where(x => x.IsClass && !x.IsAbstract);
         }
     }
 

--- a/Messaging.Buffer/IMessaging.cs
+++ b/Messaging.Buffer/IMessaging.cs
@@ -62,6 +62,15 @@ namespace Messaging.Buffer
         /// <exception cref="SubscriptionException">Subscribtion already exists or is conflicting with another</exception>
         Task SubscribeHandlers();
 
+
+        /// <summary>
+        /// Subscribe Handler
+        /// </summary>
+        /// <typeparam name="THandler"></typeparam>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <returns></returns>
+        Task SubscribeHandler<THandler, TRequest>() where THandler : HandlerBase<TRequest> where TRequest : RequestBase;
+
         /// <summary>
         /// Unsubscribe for Requests
         /// </summary>

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using Messaging.Buffer.Attributes;
 using Messaging.Buffer.Buffer;
@@ -315,6 +316,14 @@ namespace Messaging.Buffer
                 string subscribed = await handlerService.Subscribe();
                 HandlerSubscribedList.Add(subscribed);
             }
+        }
+
+        /// <inheritdoc/>
+        public async Task SubscribeHandler<THandler, TRequest>() where THandler : HandlerBase<TRequest> where TRequest : RequestBase
+        {
+            dynamic handlerService = _serviceProvider.GetRequiredService(typeof(THandler));
+            string subscribed = await handlerService.Subscribe();
+            HandlerSubscribedList.Add(subscribed);
         }
 
         #endregion

--- a/Messaging.Buffer/Messaging.cs
+++ b/Messaging.Buffer/Messaging.cs
@@ -305,8 +305,8 @@ namespace Messaging.Buffer
         /// <inheritdoc/>
         public async Task SubscribeHandlers()
         {
-            var Handlers = Reflexion.GetTypesWithAttribute<HandlerAttribute>();
-            foreach (var handler in Handlers)
+            var handlers = Reflexion.GetHandlerTypes();
+            foreach (var handler in handlers)
             {
                 if (HandlerSubscribedList.Contains(handler.Name))
                     throw new SubscriptionException($"Dupplicate handler detected. Handler : {handler.Name}.");

--- a/Messaging.Buffer/Service/MessagingConfigurator.cs
+++ b/Messaging.Buffer/Service/MessagingConfigurator.cs
@@ -42,6 +42,26 @@ namespace Messaging.Buffer.Service
             return this;
         }
 
+        /// <summary>
+        /// Register a buffer, request, response, handler
+        /// </summary>
+        /// <typeparam name="TBuffer"></typeparam>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <typeparam name="THandler"></typeparam>
+        /// <returns></returns>
+        public MessagingConfigurator AddBuffer<TBuffer, TRequest, TResponse, THandler>()
+            where TBuffer : RequestBufferBase<TRequest, TResponse>
+            where TRequest : RequestBase
+            where TResponse : ResponseBase
+            where THandler : HandlerBase<TRequest>
+        {
+            _services.AddTransient<TBuffer>();
+            _services.AddTransient<TRequest>();
+            _services.AddSingleton<THandler>();
+            return this;
+        }
+
 
         /// <summary>
         /// Register a handler for a request
@@ -58,7 +78,6 @@ namespace Messaging.Buffer.Service
         /// <summary>
         /// Register all handlers that reference HandlerAttribute
         /// </summary>
-        /// <param name="services"></param>
         /// <returns></returns>
         public MessagingConfigurator RegisterHandlers()
         {

--- a/Messaging.Buffer/Service/MessagingConfigurator.cs
+++ b/Messaging.Buffer/Service/MessagingConfigurator.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Messaging.Buffer.Buffer;
+using Messaging.Buffer.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Messaging.Buffer.Service
+{
+    /// <summary>
+    /// Configurator class for Messaging service
+    /// </summary>
+    public class MessagingConfigurator
+    {
+        private IServiceCollection _services;
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="services"></param>
+        public MessagingConfigurator(IServiceCollection services)
+        {
+            _services = services;
+        }
+
+        /// <summary>
+        /// Register a buffer, request, response
+        /// </summary>
+        /// <typeparam name="TBuffer"></typeparam>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <returns></returns>
+        public MessagingConfigurator AddBuffer<TBuffer, TRequest, TResponse>()
+            where TBuffer : RequestBufferBase<TRequest, TResponse>
+            where TRequest : RequestBase
+            where TResponse : ResponseBase
+        {
+            _services.AddTransient<TBuffer>();
+            _services.AddTransient<TRequest>();
+            return this;
+        }
+
+
+        /// <summary>
+        /// Register a handler for a request
+        /// </summary>
+        /// <typeparam name="TRequest"></typeparam>
+        /// <typeparam name="THandler"></typeparam>
+        /// <returns></returns>
+        public MessagingConfigurator RegisterHandler<TRequest, THandler>() where THandler : HandlerBase<TRequest> where TRequest : RequestBase
+        {
+            _services.AddSingleton<THandler>();
+            return this;
+        }
+
+        /// <summary>
+        /// Register all handlers that reference HandlerAttribute
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public MessagingConfigurator RegisterHandlers()
+        {
+            var handlers = Reflexion.GetHandlerTypes();
+            foreach (var handler in handlers)
+            {
+                _services.AddSingleton(handler);
+            }
+            return this;
+        }
+    }
+}

--- a/Messaging.Buffer/Service/ServiceExtension.cs
+++ b/Messaging.Buffer/Service/ServiceExtension.cs
@@ -18,59 +18,15 @@ namespace Messaging.Buffer.Service
         /// <param name="configuration"></param>
         /// <param name="configSection"></param>
         /// <returns></returns>
-        public static IServiceCollection AddMessagingBuffer(this IServiceCollection services, IConfiguration configuration, string configSection)
+        public static IServiceCollection AddMessagingBuffer(this IServiceCollection services, IConfiguration configuration, string configSection, Action<MessagingConfigurator> configurator)
         {
             services.Configure<RedisOptions>(configuration.GetSection(configSection));
 
             services.AddSingleton<IRedisCollection, RedisCollection>();
             services.AddSingleton<IMessaging, Messaging>();
 
-            return services;
-        }
+            configurator.Invoke(new MessagingConfigurator(services));
 
-        /// <summary>
-        /// Register a buffer, request, response
-        /// </summary>
-        /// <typeparam name="TBuffer"></typeparam>
-        /// <typeparam name="TRequest"></typeparam>
-        /// <typeparam name="TResponse"></typeparam>
-        /// <param name="services"></param>
-        /// <returns></returns>
-        public static IServiceCollection AddBuffer<TBuffer, TRequest, TResponse>(this IServiceCollection services)
-            where TBuffer : RequestBufferBase<TRequest, TResponse>
-            where TRequest : RequestBase
-            where TResponse : ResponseBase
-        {
-            services.AddTransient<TBuffer>();
-            services.AddTransient<TRequest>();
-            return services;
-        }
-
-        /// <summary>
-        /// Register a handler for a request
-        /// </summary>
-        /// <typeparam name="TRequest"></typeparam>
-        /// <typeparam name="THandler"></typeparam>
-        /// <param name="services"></param>
-        /// <returns></returns>
-        public static IServiceCollection RegisterHandler<TRequest, THandler>(this IServiceCollection services) where THandler : HandlerBase<TRequest> where TRequest : RequestBase
-        {
-            services.AddSingleton<THandler>();
-            return services;
-        }
-
-        /// <summary>
-        /// Register all handlers that reference HandlerAttribute
-        /// </summary>
-        /// <param name="services"></param>
-        /// <returns></returns>
-        public static IServiceCollection RegisterHandlers(this IServiceCollection services)
-        {
-            var handlers = Reflexion.GetHandlerTypes();
-            foreach (var handler in handlers)
-            {
-                services.AddSingleton(handler);
-            }
             return services;
         }
 

--- a/Messaging.Buffer/Service/ServiceExtension.cs
+++ b/Messaging.Buffer/Service/ServiceExtension.cs
@@ -66,8 +66,8 @@ namespace Messaging.Buffer.Service
         /// <returns></returns>
         public static IServiceCollection RegisterHandlers(this IServiceCollection services)
         {
-            var handlers = Reflexion.GetTypesWithAttribute<HandlerAttribute>();
-            foreach(var handler in handlers)
+            var handlers = Reflexion.GetHandlerTypes();
+            foreach (var handler in handlers)
             {
                 services.AddSingleton(handler);
             }

--- a/WebAppExample/Startup.cs
+++ b/WebAppExample/Startup.cs
@@ -29,10 +29,11 @@ namespace WebAppExample
             services.AddControllers();
             services.AddMvc(o => o.EnableEndpointRouting = false);
 
-            services.AddMessagingBuffer(Configuration, "Redis");
+            services.AddMessagingBuffer(Configuration, "Redis", (cfg) =>
+            {
+                cfg.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse>();
+            });
             services.AddSingleton<MessagingService>();
-
-            services.AddBuffer<HelloWorldRequestBuffer, HelloWorldRequest, HelloWorldResponse>();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IHostApplicationLifetime applicationLifetime)


### PR DESCRIPTION
Refacto: 
- Remove the need for Handler attribute when writting a Handle class
- Reflexion: Handler types are found only by checking the abstract parent attribute (Handler attribute not needed anymore in the Handler class)
- Registration for Buffers and Handlers are done using a configurator (when calling AddMessaging) instead of calling a method from IServiceCollection.
- 
Add: 
- Can subscribe single Handler (instead of all at once)
- Can register buffer, request, response and handler all in same time.